### PR TITLE
Xslt mapping updates

### DIFF
--- a/src/Import/jats2opus_xml.xslt
+++ b/src/Import/jats2opus_xml.xslt
@@ -50,11 +50,23 @@
                 <xsl:attribute name="serverState">
                     <xsl:text>unpublished</xsl:text>
                 </xsl:attribute>
+                <xsl:if test="//article-meta/counts/page-count/@count">
+                    <xsl:attribute name="pageNumber">
+                    <xsl:value-of select="//article-meta/counts/page-count/@count"/>
+                    </xsl:attribute>
+                </xsl:if>
+
                 <titlesMain>
                     <titleMain>
                         <xsl:attribute name="language"><xsl:value-of select="$lang"/></xsl:attribute>
-                        <xsl:value-of select="//article-meta/title-group/article-title"/>
+                        <xsl:value-of select="normalize-space(//article-meta/title-group/article-title)"/>
                     </titleMain>
+                    <xsl:for-each select="//article-meta/title-group/trans-title-group/trans-title">
+                        <titleMain>
+                            <xsl:call-template name="insert-lang-attrib"/>
+                            <xsl:value-of select="normalize-space()"/>
+                        </titleMain>
+                    </xsl:for-each>
                 </titlesMain>
                 <titles>
                     <xsl:for-each select="//journal-meta//journal-title">
@@ -64,18 +76,53 @@
                             <xsl:value-of select="normalize-space(text())"/>
                         </title>
                     </xsl:for-each>
-                </titles>
-                <abstracts>
-                    <xsl:if test="//article-meta/abstract">
-                        <abstract>
-                            <xsl:attribute name="language"><xsl:value-of select="$lang"/></xsl:attribute>
-                            <xsl:value-of select="//article-meta/abstract"/>
-                        </abstract>
+                     <xsl:if test="//article-meta/title-group/subtitle[not(@content-type='running-title') and not(@content-type='running-author')]">
+                        <!-- exclude page headers from Springer -->
+                        <title>
+                        <xsl:attribute name="language"><xsl:value-of select="$lang"/></xsl:attribute>
+                        <xsl:attribute name="type"><xsl:text>sub</xsl:text></xsl:attribute>
+                        <xsl:value-of select="normalize-space(//article-meta/title-group/subtitle[not(@content-type='running-title') and not(@content-type='running-author')])"/>
+                        </title>
                     </xsl:if>
-                </abstracts>
+                    <xsl:for-each select="//article-meta/title-group/trans-title-group/trans-subtitle">
+                        <title>
+                        <xsl:call-template name="insert-lang-attrib"/>
+                        <xsl:attribute name="type"><xsl:text>sub</xsl:text></xsl:attribute>
+                        <xsl:value-of select="normalize-space()"/>
+                        </title>
+                    </xsl:for-each>
+                </titles>
+
+                <xsl:if test="//article-meta/abstract[not(@abstract-type='graphical')
+                                            and not(@abstract-type='toc')
+                                            and not(@abstract-type='precis')]
+                                        or //article-meta/trans-abstract">
+                    <abstracts>
+                        <xsl:if test="//article-meta/abstract[not(@abstract-type='graphical')
+                                              and not(@abstract-type='toc')
+                                              and not(@abstract-type='precis')]">
+                            <abstract>
+                                <!-- selecting the first non-toc non-grapical non-precis abstract -->
+                                <xsl:attribute name="language"><xsl:value-of select="$lang"/></xsl:attribute>
+                                <xsl:value-of select="//article-meta/abstract[not(@abstract-type='graphical')
+                                                                            and not(@abstract-type='toc')
+                                                                            and not(@abstract-type='precis')]"/>
+                            </abstract>
+                        </xsl:if>
+                        <xsl:for-each select="//article-meta/trans-abstract">
+                            <abstract>
+                                <xsl:call-template name="insert-lang-attrib"/>
+                                <xsl:value-of select="."/>
+                            </abstract>
+                        </xsl:for-each>
+                  </abstracts>
+                </xsl:if>
                 <persons>
                     <xsl:for-each select="//article-meta/contrib-group/contrib">
-                        <xsl:if test="string-length(normalize-space(name/surname/text()))>0">
+                        <xsl:if test="string-length(normalize-space(.//surname/text()))>0 and
+                                                (@contrib-type='guest-editor' or
+                                                @contrib-type='editor' or
+                                                @contrib-type='author')">
                             <person>
                                 <xsl:attribute name="role">
                                     <xsl:choose>
@@ -87,8 +134,31 @@
                                         </xsl:otherwise>
                                     </xsl:choose>
                                 </xsl:attribute>
-                                <xsl:attribute name="firstName"><xsl:value-of select="name/given-names"/></xsl:attribute>
-                                <xsl:attribute name="lastName"><xsl:value-of select="name/surname"/></xsl:attribute>
+                                <xsl:attribute name="firstName"><xsl:value-of select=".//given-names"/></xsl:attribute>
+                                <xsl:attribute name="lastName"><xsl:value-of select=".//surname"/></xsl:attribute>
+                                <xsl:if test=".//email">
+                                    <xsl:attribute name="email"><xsl:value-of select=".//email"/></xsl:attribute>
+                                </xsl:if>
+                                <xsl:if test="./contrib-id[@contrib-id-type='orcid']">
+                                    <identifiers>
+                                        <identifier type='orcid'>
+                                        <xsl:variable name='orcid' select="./contrib-id[@contrib-id-type='orcid']/text()"/>
+                                        <xsl:choose>
+                                            <xsl:when test="substring($orcid, string-length($orcid))='/'">
+                                                <xsl:variable name="orcid2" select="substring($orcid, 1, string-length($orcid)-1)"/>
+                                                <xsl:call-template name="insert-orcid">
+                                                <xsl:with-param name="orcid" select="$orcid2"/>
+                                                </xsl:call-template>
+                                            </xsl:when>
+                                            <xsl:otherwise>
+                                                <xsl:call-template name="insert-orcid">
+                                                <xsl:with-param name="orcid" select="$orcid"/>
+                                                </xsl:call-template>
+                                            </xsl:otherwise>
+                                        </xsl:choose>
+                                    </identifier>
+                                </identifiers>
+                            </xsl:if>
                             </person>
                         </xsl:if>
                     </xsl:for-each>
@@ -113,23 +183,17 @@
                 <dates>
                     <xsl:for-each select="//article-meta/pub-date">
                         <xsl:choose>
-                            <xsl:when test="contains(@pub-type,'epub') and year and month">
+                            <xsl:when test="(contains(@pub-type,'epub') and year) or
+                                        (contains(@pub-type,'ppub') and year) or
+                                        (contains(@pub-type, 'epub-ppub') and year) or
+                                        (contains(@date-type,'pub') and year) or
+                                        (not(@*) and year)">
                                 <xsl:call-template name="compose-date">
-                                    <!-- <xsl:with-param name="xpub" select="'epub'"/> -->
-                                </xsl:call-template>
-                            </xsl:when>
-                            <xsl:when test="contains(@pub-type,'ppub') and year and month">
-                                <xsl:call-template name="compose-date">
-                                    <!-- <xsl:with-param name="xpub" select="'ppub'"/> -->
-                                </xsl:call-template>
-                            </xsl:when>
-                            <xsl:when test="contains(@date-type,'pub') and year and month">
-                                <xsl:call-template name="compose-date">
-                                    <!-- <xsl:with-param name="xpub" select="'pub'"/> -->
                                 </xsl:call-template>
                             </xsl:when>
                             <xsl:otherwise>
                                 <xsl:if test="not(year)">
+                                    <!--to comply with opus requirement that a date has to be given-->
                                     <date>
                                         <xsl:attribute name="type"><xsl:text>completed</xsl:text></xsl:attribute>
                                         <xsl:attribute name="monthDay">
@@ -197,6 +261,46 @@
                 <xsl:value-of select="$xpath/year"/>
             </xsl:attribute>
         </date>
+    </xsl:template>
+
+    <xsl:template name="insert-orcid">
+        <xsl:param name="orcid"/>
+        <!-- This template accepts an url as input and selects the substring after the last "/".
+        orcids consist of four 4-digit blocks, separated by dashes. i.e. the resulting string should be precisely 19 characters long.
+        Lacking any regex capabilities in xslt 1.0, the template makes a last check for string-length before returning the orcid-id.
+        Recursive template, as substring-after() can only ever select the substring after the first instance of a character.
+        -->
+        <xsl:choose>
+        <xsl:when test="not(contains($orcid,'/'))">
+            <xsl:if test="string-length($orcid)=19">
+            <xsl:value-of select="$orcid"/>
+            </xsl:if>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:call-template name="insert-orcid">
+            <xsl:with-param name="orcid" select="substring-after($orcid,'/')"/>
+            </xsl:call-template>
+        </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="insert-lang-attrib">
+    <!-- try to insert local language attribute, or fallback to global language variable -->
+        <xsl:choose>
+            <xsl:when test="@xml:lang">
+                <xsl:attribute name="language">
+                    <xsl:value-of select="php:functionString('Opus\I18n\Languages::getPart2b', @xml:lang)"/>
+                </xsl:attribute>
+            </xsl:when>
+            <xsl:when test="../@xml:lang">
+                <xsl:attribute name="language">
+                    <xsl:value-of select="php:functionString('Opus\I18n\Languages::getPart2b', ../@xml:lang)"/>
+                </xsl:attribute>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:attribute name="language"><xsl:value-of select="$lang"/></xsl:attribute>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/src/Import/jats2opus_xml.xslt
+++ b/src/Import/jats2opus_xml.xslt
@@ -101,18 +101,20 @@
                         <xsl:if test="//article-meta/abstract[not(@abstract-type='graphical')
                                               and not(@abstract-type='toc')
                                               and not(@abstract-type='precis')]">
-                            <abstract>
-                                <!-- selecting the first non-toc non-grapical non-precis abstract -->
-                                <xsl:attribute name="language"><xsl:value-of select="$lang"/></xsl:attribute>
-                                <xsl:value-of select="//article-meta/abstract[not(@abstract-type='graphical')
-                                                                            and not(@abstract-type='toc')
-                                                                            and not(@abstract-type='precis')]"/>
-                            </abstract>
+                            <xsl:for-each select="//article-meta/abstract[not(@abstract-type='graphical')
+                                    and not(@abstract-type='toc')
+                                    and not(@abstract-type='precis')][1]">
+                                <abstract>
+                                    <!-- selecting the first non-toc non-grapical non-precis abstract -->
+                                    <xsl:attribute name="language"><xsl:value-of select="$lang"/></xsl:attribute>
+                                    <xsl:call-template name="insert-abstract"/>
+                                </abstract>
+                            </xsl:for-each>
                         </xsl:if>
                         <xsl:for-each select="//article-meta/trans-abstract">
                             <abstract>
                                 <xsl:call-template name="insert-lang-attrib"/>
-                                <xsl:value-of select="."/>
+                                <xsl:call-template name="insert-abstract"/>
                             </abstract>
                         </xsl:for-each>
                   </abstracts>
@@ -302,5 +304,57 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
+
+    <xsl:template name="insert-abstract">
+        <!-- Transform abstract content to normalize whitespacing between child elements.
+        Any tex-math content is exluded and title "Abstract" as well.
+        -->
+    <xsl:choose>
+      <xsl:when test="descendant::sub">
+      <!-- abstract contains chemical formulas, no whitespace normalization will be done -->
+        <xsl:for-each select="descendant-or-self::text()">
+          <xsl:if test="string-length(normalize-space())&gt;0">
+            <xsl:choose>
+              <xsl:when test="local-name(parent::*)='tex-math'
+                              or (local-name(parent::*)='title' and .='Abstract')">
+              <!--ignore tex-math elements and skip "Abstract" headers-->
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:value-of select="."/>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:for-each select="descendant-or-self::text()">
+          <xsl:if test="string-length(normalize-space())&gt;0">
+            <xsl:choose>
+              <xsl:when test="local-name(parent::*)='title' and not(.='Abstract')">
+              <!-- when text of title element is selected, add line breaks before and after-->
+                <xsl:text>
+                </xsl:text>
+                <xsl:value-of select="normalize-space()"/>
+                <xsl:text>
+                </xsl:text>
+              </xsl:when>
+              <xsl:when test="local-name(parent::*)='tex-math'
+                              or (local-name(parent::*)='title' and .='Abstract')">
+              <!--ignore tex-math elements and skip "Abstract" headers-->
+              </xsl:when>
+              <xsl:when test="contains(name(parent::*),'mml:')">
+                <xsl:value-of select="."/>
+              </xsl:when>
+              <xsl:otherwise> <!--otherwise select text and add a whitespace afterward-->
+                <xsl:value-of select="normalize-space()"/>
+                <xsl:text> </xsl:text>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
 
 </xsl:stylesheet>

--- a/src/Import/jats2opus_xml.xslt
+++ b/src/Import/jats2opus_xml.xslt
@@ -242,7 +242,7 @@
                 <xsl:text>--</xsl:text>
                 <xsl:choose>
                     <!-- <xsl:when test="//article-meta/pub-date[contains(@pub-type,$xpub)]/month"> -->
-                    <xsl:when test="$xpath/month">
+                    <xsl:when test="number($xpath/month) = $xpath/month">
                         <xsl:value-of select="format-number($xpath/month,'00')"/>
                     </xsl:when>
                     <xsl:otherwise>

--- a/src/Import/jats2opus_xml.xslt
+++ b/src/Import/jats2opus_xml.xslt
@@ -3,7 +3,6 @@
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:php="http://php.net/xsl">
 
-    <!-- <xsl:import href="outputTokens.xsl"/> -->
     <xsl:output method="xml" omit-xml-declaration="yes" indent="yes" encoding="utf-8"/>
 
     <xsl:variable name="lang" select="php:functionString('Opus\I18n\Languages::getPart2b', /article/@xml:lang)"/>
@@ -51,22 +50,6 @@
                 <xsl:attribute name="serverState">
                     <xsl:text>unpublished</xsl:text>
                 </xsl:attribute>
-                <!--
-                language="eng"
-                type="article|bachelorthesis|bookpart|book|conferenceobject|contributiontoperiodical|coursematerial|diplom|doctoralthesis|examen|habilitation|image|lecture|magister|masterthesis|movingimage|other|periodical|preprint|report|review|studythesis|workingpaper"
-                pageFirst=""
-                pageLast=""
-                pageNumber=""
-                edition=""
-                volume=""
-                issue=""
-                publisherName=""
-                publisherPlace=""
-                creatingCorporation=""
-                contributingCorporation=""
-                belongsToBibliography="true|false"
-                serverState="audited|published|restricted|inprogress|unpublished"
-                -->
                 <titlesMain>
                     <titleMain>
                         <xsl:attribute name="language"><xsl:value-of select="$lang"/></xsl:attribute>
@@ -106,21 +89,6 @@
                                 </xsl:attribute>
                                 <xsl:attribute name="firstName"><xsl:value-of select="name/given-names"/></xsl:attribute>
                                 <xsl:attribute name="lastName"><xsl:value-of select="name/surname"/></xsl:attribute>
-                                <!--
-                                role="advisor|author|contributor|editor|referee|translator|submitter|other"
-                                firstName=""
-                                lastName=""
-                                academicTitle=""
-                                email=""
-                                allowEmailContact="true|false"
-                                placeOfBirth=""
-                                dateOfBirth="1999-12-31"
-                                -->
-                                <!--
-                                <identifiers>
-                                  <identifier type="orcid|gnd|intern">?????</identifier>
-                                </identifiers>
-                                -->
                             </person>
                         </xsl:if>
                     </xsl:for-each>
@@ -141,22 +109,8 @@
                         </xsl:if>
                     </xsl:for-each>
                 </keywords>
-                <!--
-                <dnbInstitutions>
-                    <dnbInstitution id="<integer>" role="grantor|publisher"/>
-                </dnbInstitutions>
-                -->
+
                 <dates>
-                    <!--
-                    <xsl:for-each select="//article-meta/pub-date">
-                       <xsl:if test="(contains(@pub-type, 'epub') and year and month) or
-                                     (contains(@publication-format, 'electronic') and contains(@date-type, 'pub') and year and month)">
-                          <mods:dateIssued encoding="iso8601">
-                             <xsl:call-template name="compose-date"></xsl:call-template>
-                          </mods:dateIssued>
-                       </xsl:if>
-                </xsl:for-each>
-                    -->
                     <xsl:for-each select="//article-meta/pub-date">
                         <xsl:choose>
                             <xsl:when test="contains(@pub-type,'epub') and year and month">
@@ -210,73 +164,6 @@
                         </identifier>
                     </xsl:if>
                 </identifiers>
-                <!--
-                <identifiers>
-                    <identifier>
-                       <xsl:for-each select="//journal-meta/issn[@pub-type='ppub' or @publication-format='print']">
-                          <xsl:value-of select="normalize-space(text())"/>
-                          <xsl:if test="position() != last()">
-                             <xsl:text> , </xsl:text>
-                          </xsl:if>
-                          <xsl:if test="position() = last()">
-                             <xsl:text> (pISSN)</xsl:text>
-                          </xsl:if>
-                       </xsl:for-each>
-                       <xsl:if test="//journal-meta/issn[@pub-type='epub' or @publication-format='electronic']">
-                          <xsl:text> ; </xsl:text>
-                          <xsl:for-each select="//journal-meta/issn[@pub-type='epub' or @publication-format='electronic']">
-                             <xsl:value-of select="normalize-space(text())"/>
-                             <xsl:if test="position() != last()">
-                                <xsl:text> , </xsl:text>
-                             </xsl:if>
-                             <xsl:if test="position() = last()">
-                                <xsl:text> (eISSN)</xsl:text>
-                             </xsl:if>
-                          </xsl:for-each>
-                       </xsl:if>
-                    </identifier>
-                    <identifier>
-                       <xsl:attribute name="type"><xsl:text>doi</xsl:text></xsl:attribute>
-                       <xsl:value-of select="//article-meta/article-id[@pub-id-type='doi']"/>
-                    </identifier>
-                  <xsl:if test="//article-meta/article-id[@pub-id-type='pmid']">
-                    <identifier>
-                       <xsl:attribute name="type"><xsl:text>pmid</xsl:text></xsl:attribute>
-                       <xsl:value-of select="//article-meta/article-id[@pub-id-type='pmid']"/>
-                    </identifier>
-                  </xsl:if>
-                </identifiers>
-                -->
-                <!--
-                <notes>
-                    <note visibility="private|public">?????</note>
-                </notes>
-                <collections>
-                    <collection id="<integer>"/>
-                </collections>
-                <series>
-                    <seriesItem id="<integer>" number=""/>
-                </series>
-                <enrichments>
-                    <enrichment key="">?????</enrichment>
-                </enrichments>
-                <licences>
-                    <licence id="<integer>"/>
-                </licences>
-                <files basedir="">
-                    <file
-                          path=""
-                          name=""
-                          language=""
-                          displayName=""
-                          visibleInOai="true|false"
-                          visibleInFrontdoor="true|false"
-                          sortOrder="<int>">
-                      <comment>?????</comment>
-                      <checksum type="md5|sha256|sha512">?????</checksum>
-                    </file>
-                </files>
-                -->
             </opusDocument>
         </import>
     </xsl:template>


### PR DESCRIPTION
- New: subtitles, translated titles and abstracts, page count, author email and orcid
- Improved selection of publication dates and of author names (ie, insert `.//given-names` instead of `./name/given-names` to accommodate alternative usage of `string-name` instead of `name`)
- Exclude non-editor/non-author contributors
- Exclude "precis" abstracts (needed for Elsevier)
- Add abstract template to normalize whitespacing and add linebreaks where needed. (Plus, exclude tex-math content and "Abstract" titles)


Potential performance issues:
- orcid template recursively calls itself - should be no more than once or twice per orcid --> could be replaced with a php function transforming the canonical URL (https://orcid.org/0009-0009-8026-7701) to the form required by OPUS (0009-0009-8026-7701)
- the abstract template goes over every child element individually, this may slow down performance if many functions / MathML children exist ( added separately in the last commit )